### PR TITLE
Switch from terraform-aws-kops-metadata to terraform-aws-kops-data-iam

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,10 +9,8 @@ module "label" {
 }
 
 module "kops_metadata" {
-  source       = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.2.1"
-  dns_zone     = "${var.cluster_name}"
-  masters_name = "${var.masters_name}"
-  nodes_name   = "${var.nodes_name}"
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-data-iam.git?ref=tags/0.1.0"
+  cluster_name = "${var.cluster_name}"
 }
 
 resource "aws_iam_role" "default" {


### PR DESCRIPTION
## what
Switch from using https://github.com/cloudposse/terraform-aws-kops-metadata to https://github.com/cloudposse/terraform-aws-kops-data-iam
## why
Fixes failure of previous version when kops VPC ID cannot be found